### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "ng2-search-filter": "^0.4.7",
     "ngx-order-pipe": "^2.0.2",
     "ngx-pagination": "^3.2.1",
-    "npm": "^6.9.0",
     "rxjs": "~6.3.3",
     "tslib": "^1.9.0",
     "zone.js": "~0.8.26"


### PR DESCRIPTION

Hello ShreyashApp!

It seems like you have npm as one of your (dev-) dependency in my-app.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
